### PR TITLE
0-byte file fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,11 @@
 AllCops:
   TargetRubyVersion: 2.1
+
+Metrics/AbcSize:
+  Max: 50
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/MethodLength:
+  Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,2 @@
 AllCops:
   TargetRubyVersion: 2.1
-
-Metrics/AbcSize:
-  Max: 50
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/MethodLength:
-  Max: 20

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install it like:
 ```shell
 
   $ S3_BUCKET=bucket_name \
-    S3_BUCKET_KEY=bucket_key \
+    S3_BUCKET_PREFIX=bucket_key \
     BACKUP_SRC_DIR=/path/to/data \
     BACKUP_DEST_DIR=/backups \
     BACKUP_FREQ="*/30 * * * *" \
@@ -57,4 +57,3 @@ The gem is available as open source under the terms of the [MIT License][MIT].
 
 [rubygems]: https://rubygems.org
 [MIT]: http://opensource.org/licenses/MIT
-

--- a/backupsss.gemspec
+++ b/backupsss.gemspec
@@ -6,10 +6,11 @@ require 'backupsss/version'
 Gem::Specification.new do |spec|
   spec.name          = 'backupsss'
   spec.version       = Backupsss::VERSION
-  spec.authors       = ['Reppard Walker', 'Jonathan Niesen']
+  spec.authors       = ['Reppard Walker', 'Jonathan Niesen', 'Jason Antman']
   spec.email         = [
     'reppard.walker@manheim.com',
-    'jonathan.niesen@manheim.com'
+    'jonathan.niesen@manheim.com',
+    'jason@jasonantman.com'
   ]
 
   spec.homepage      = 'https://github.com/manheim/backupsss'

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   ruby:
     version:
-      2.2.3
+      2.2.5
 dependencies:
   pre:
     - gem install bundler --no-rdoc --no-ri -v 1.11.2

--- a/lib/backupsss.rb
+++ b/lib/backupsss.rb
@@ -66,7 +66,12 @@ module Backupsss
     def run
       scheduler = Rufus::Scheduler.new
       scheduler.cron(config.backup_freq, blocking: true) do
-        call
+        begin
+          call
+        rescue => exc
+          STDERR.puts "ERROR - backup failed: #{exc.message}"
+          STDERR.puts exc.backtrace.join("\n\t")
+        end
       end
       scheduler.join
     end

--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -12,20 +12,17 @@ module Backupsss
     end
 
     def make
-      if valid_dest? && valid_src?
-        _, err, status = Open3.capture3("#{tar_command} #{dest} #{src}")
-        STDERR.puts "tar command stderr:\n#{err}" unless err.empty?
-        if status.exitstatus != 0
-          raise "ERROR: #{tar_command} exited #{status.exitstatus}"
-        end
-        unless File.exist?(dest)
-          raise "ERROR: Tar destination file does not exist"
-        end
-        if File.size(dest) == 0
-          raise "ERROR: Tar destionation file is 0 bytes."
-        end
-        File.open(dest)
+      return nil unless valid_dest? && valid_src?
+      _, err, status = Open3.capture3("#{tar_command} #{dest} #{src}")
+      STDERR.puts "tar command stderr:\n#{err}" unless err.empty?
+      if status.exitstatus.nonzero?
+        raise "ERROR: #{tar_command} exited #{status.exitstatus}"
       end
+      unless File.exist?(dest)
+        raise 'ERROR: Tar destination file does not exist'
+      end
+      raise 'ERROR: Tar destionation file is 0 bytes.' if File.size(dest).zero?
+      File.open(dest)
     end
 
     def valid_dest?

--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -13,7 +13,17 @@ module Backupsss
 
     def make
       if valid_dest? && valid_src?
-        Open3.capture3("#{tar_command} #{dest} #{src}")
+        _, err, status = Open3.capture3("#{tar_command} #{dest} #{src}")
+        STDERR.puts "tar command stderr:\n#{err}" unless err.empty?
+        if status.exitstatus != 0
+          raise "ERROR: #{tar_command} exited #{status.exitstatus}"
+        end
+        unless File.exist?(dest)
+          raise "ERROR: Tar destination file does not exist"
+        end
+        if File.size(dest) == 0
+          raise "ERROR: Tar destionation file is 0 bytes."
+        end
         File.open(dest)
       end
     end

--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -15,6 +15,11 @@ module Backupsss
       return nil unless valid_dest? && valid_src?
       _, err, status = Open3.capture3("#{tar_command} #{dest} #{src}")
       STDERR.puts "tar command stderr:\n#{err}" unless err.empty?
+      check_tar_result(status)
+      File.open(dest)
+    end
+
+    def check_tar_result(status)
       if status.exitstatus.nonzero?
         raise "ERROR: #{tar_command} exited #{status.exitstatus}"
       end
@@ -22,7 +27,6 @@ module Backupsss
         raise 'ERROR: Tar destination file does not exist'
       end
       raise 'ERROR: Tar destionation file is 0 bytes.' if File.size(dest).zero?
-      File.open(dest)
     end
 
     def valid_dest?

--- a/spec/backupsss/janitor_spec.rb
+++ b/spec/backupsss/janitor_spec.rb
@@ -65,7 +65,9 @@ describe Backupsss::Janitor do
 
     context 'when provided garbage can be cleaned up' do
       let(:message) do
-        msg = garbage.inject([]) { |a, e| a << "Cleaning up #{e}" }.join("\n")
+        msg = garbage.inject([]) do |acc, elem|
+          acc << "Cleaning up #{elem}"
+        end.join("\n")
         msg << "\nFinished cleaning up."
       end
 

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -99,13 +99,29 @@ describe Backupsss::Tar do
     end
 
     context 'when src and dest dir exist with correct permissions' do
-      before  { FileUtils.mkdir_p(src) }
-      before  { FileUtils.mkdir_p(File.dirname(dest)) }
-      after   { FileUtils.rm_rf(src) }
-      after   { FileUtils.rm_rf(File.dirname(dest)) }
-      subject { Backupsss::Tar.new(src, dest).make }
+      let(:subject) { Backupsss::Tar.new(src, dest) }
+      let(:dbl_file) { double(File) }
+      before(:each) do
+        allow(subject).to receive(:valid_dest?).and_return(true)
+        allow(subject).to receive(:valid_src?).and_return(true)
+        allow(subject).to receive(:tar_command).and_return('tarcmd')
+        allow(Open3).to receive(:capture3)
+        allow(File).to receive(:open).and_return(dbl_file)
+      end
 
-      it { is_expected.to be_a(File) }
+      it 'calls the appropriate command' do
+        expect(subject).to receive(:valid_dest?).once.ordered
+        expect(subject).to receive(:valid_src?).once.ordered
+        expect(Open3).to receive(:capture3).once.ordered
+          .with("tarcmd #{dest} #{src}")
+        subject.make
+      end
+      it 'returns the open File object' do
+        expect(subject).to receive(:valid_dest?).once.ordered
+        expect(subject).to receive(:valid_src?).once.ordered
+        expect(File).to receive(:open).once.ordered.with(dest)
+        expect(subject.make).to eq(dbl_file)
+      end
     end
   end
 end

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -112,115 +112,68 @@ describe Backupsss::Tar do
         allow(subject).to receive(:valid_dest?).and_return(true)
         allow(subject).to receive(:valid_src?).and_return(true)
         allow(subject).to receive(:tar_command).and_return('tarcmd')
+        allow(subject).to receive(:check_tar_result)
         allow(Open3).to receive(:capture3).and_return(['', '', dbl_status])
         allow(STDERR).to receive(:puts)
-        allow(File).to receive(:exist?).and_return(true)
-        allow(File).to receive(:size).and_return(999)
         allow(File).to receive(:open).and_return(dbl_file)
       end
 
-      it 'calls the appropriate command' do
+      it 'validates inputs, calls the command and checks the result' do
         expect(subject).to receive(:valid_dest?).once.ordered
         expect(subject).to receive(:valid_src?).once.ordered
         expect(Open3).to receive(:capture3).once.ordered
           .with("tarcmd #{dest} #{src}")
         expect(STDERR).to_not receive(:puts)
-        expect(File).to receive(:exist?).once.ordered.with(dest)
-        expect(File).to receive(:size).once.ordered.with(dest)
+        expect(subject).to receive(:check_tar_result).once.ordered
+          .with(dbl_status)
         subject.make
       end
 
       it 'returns the open File object' do
-        expect(subject).to receive(:valid_dest?).once.ordered
-        expect(subject).to receive(:valid_src?).once.ordered
-        expect(STDERR).to_not receive(:puts)
-        expect(File).to receive(:exist?).once.ordered.with(dest)
-        expect(File).to receive(:size).once.ordered.with(dest)
-        expect(File).to receive(:open).once.ordered.with(dest)
         expect(subject.make).to eq(dbl_file)
       end
     end
+  end
+
+  describe '#check_tar_result' do
     context 'when tar exits non-zero' do
       let(:subject) { Backupsss::Tar.new(src, dest) }
-      let(:dbl_file) { double(File) }
       let(:dbl_status) { dbl_exitstatus(3) }
-      before(:each) do
-        allow(subject).to receive(:valid_dest?).and_return(true)
-        allow(subject).to receive(:valid_src?).and_return(true)
+      it 'raises an error' do
         allow(subject).to receive(:tar_command).and_return('tarcmd')
-        allow(Open3).to receive(:capture3)
-          .and_return(['', 'some stderr', dbl_status])
-        allow(STDERR).to receive(:puts)
         allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:size).and_return(999)
-        allow(File).to receive(:open).and_return(dbl_file)
-      end
 
-      it 'raises an error' do
-        expect(subject).to receive(:valid_dest?).once.ordered
-        expect(subject).to receive(:valid_src?).once.ordered
-        expect(Open3).to receive(:capture3).once.ordered
-          .with("tarcmd #{dest} #{src}")
-        expect(STDERR).to receive(:puts).once.ordered
-          .with("tar command stderr:\nsome stderr")
-        expect(File).to_not receive(:open)
-        expect { subject.make }
+        expect { subject.check_tar_result(dbl_status) }
           .to raise_error(RuntimeError, /ERROR: tarcmd exited 3/)
       end
     end
     context 'when destination file does not exist' do
       let(:subject) { Backupsss::Tar.new(src, dest) }
-      let(:dbl_file) { double(File) }
       let(:dbl_status) { dbl_exitstatus(0) }
-      before(:each) do
-        allow(subject).to receive(:valid_dest?).and_return(true)
-        allow(subject).to receive(:valid_src?).and_return(true)
+      it 'raises an error' do
         allow(subject).to receive(:tar_command).and_return('tarcmd')
-        allow(Open3).to receive(:capture3).and_return(['', '', dbl_status])
-        allow(STDERR).to receive(:puts)
         allow(File).to receive(:exist?).and_return(false)
         allow(File).to receive(:size).and_return(999)
-        allow(File).to receive(:open).and_return(dbl_file)
-      end
 
-      it 'raises an error' do
-        expect(subject).to receive(:valid_dest?).once.ordered
-        expect(subject).to receive(:valid_src?).once.ordered
-        expect(Open3).to receive(:capture3).once.ordered
-          .with("tarcmd #{dest} #{src}")
-        expect(STDERR).to_not receive(:puts)
         expect(File).to receive(:exist?).once.with(dest)
-        expect(File).to_not receive(:open)
-        expect { subject.make }.to raise_error(
+        expect(File).to_not receive(:size)
+        expect { subject.check_tar_result(dbl_status) }.to raise_error(
           RuntimeError, /ERROR: Tar destination file does not exist/
         )
       end
     end
     context 'when destination file is 0 bytes' do
       let(:subject) { Backupsss::Tar.new(src, dest) }
-      let(:dbl_file) { double(File) }
       let(:dbl_status) { dbl_exitstatus(0) }
-      before(:each) do
-        allow(subject).to receive(:valid_dest?).and_return(true)
-        allow(subject).to receive(:valid_src?).and_return(true)
+      it 'raises an error' do
         allow(subject).to receive(:tar_command).and_return('tarcmd')
-        allow(Open3).to receive(:capture3).and_return(['', '', dbl_status])
-        allow(STDERR).to receive(:puts)
         allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:size).and_return(0)
-        allow(File).to receive(:open).and_return(dbl_file)
-      end
 
-      it 'raises an error' do
-        expect(subject).to receive(:valid_dest?).once.ordered
-        expect(subject).to receive(:valid_src?).once.ordered
-        expect(Open3).to receive(:capture3).once.ordered
-          .with("tarcmd #{dest} #{src}")
-        expect(STDERR).to_not receive(:puts)
         expect(File).to receive(:exist?).once.ordered.with(dest)
         expect(File).to receive(:size).once.ordered.with(dest)
-        expect(File).to_not receive(:open)
-        expect { subject.make }.to raise_error(
+        expect { subject.check_tar_result(dbl_status) }.to raise_error(
           RuntimeError, /ERROR: Tar destionation file is 0 bytes\./
         )
       end

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 require 'backupsss/tar'
 
+def dbl_exitstatus(code)
+  d = double
+  allow(d).to receive(:exitstatus).and_return(code)
+  d
+end
+
 describe Backupsss::Tar do
   let(:src)      { 'spec/fixtures/backup_src' }
   let(:filename) { 'backup.tar' }
@@ -101,11 +107,15 @@ describe Backupsss::Tar do
     context 'when src and dest dir exist with correct permissions' do
       let(:subject) { Backupsss::Tar.new(src, dest) }
       let(:dbl_file) { double(File) }
+      let(:dbl_status) { dbl_exitstatus(0) }
       before(:each) do
         allow(subject).to receive(:valid_dest?).and_return(true)
         allow(subject).to receive(:valid_src?).and_return(true)
         allow(subject).to receive(:tar_command).and_return('tarcmd')
-        allow(Open3).to receive(:capture3)
+        allow(Open3).to receive(:capture3).and_return(['', '', dbl_status])
+        allow(STDERR).to receive(:puts)
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:size).and_return(999)
         allow(File).to receive(:open).and_return(dbl_file)
       end
 
@@ -114,13 +124,103 @@ describe Backupsss::Tar do
         expect(subject).to receive(:valid_src?).once.ordered
         expect(Open3).to receive(:capture3).once.ordered
           .with("tarcmd #{dest} #{src}")
+        expect(STDERR).to_not receive(:puts)
+        expect(File).to receive(:exist?).once.ordered.with(dest)
+        expect(File).to receive(:size).once.ordered.with(dest)
         subject.make
       end
+
       it 'returns the open File object' do
         expect(subject).to receive(:valid_dest?).once.ordered
         expect(subject).to receive(:valid_src?).once.ordered
+        expect(STDERR).to_not receive(:puts)
+        expect(File).to receive(:exist?).once.ordered.with(dest)
+        expect(File).to receive(:size).once.ordered.with(dest)
         expect(File).to receive(:open).once.ordered.with(dest)
         expect(subject.make).to eq(dbl_file)
+      end
+    end
+    context 'when tar exits non-zero' do
+      let(:subject) { Backupsss::Tar.new(src, dest) }
+      let(:dbl_file) { double(File) }
+      let(:dbl_status) { dbl_exitstatus(3) }
+      before(:each) do
+        allow(subject).to receive(:valid_dest?).and_return(true)
+        allow(subject).to receive(:valid_src?).and_return(true)
+        allow(subject).to receive(:tar_command).and_return('tarcmd')
+        allow(Open3).to receive(:capture3)
+          .and_return(['', 'some stderr', dbl_status])
+        allow(STDERR).to receive(:puts)
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:size).and_return(999)
+        allow(File).to receive(:open).and_return(dbl_file)
+      end
+
+      it 'raises an error' do
+        expect(subject).to receive(:valid_dest?).once.ordered
+        expect(subject).to receive(:valid_src?).once.ordered
+        expect(Open3).to receive(:capture3).once.ordered
+          .with("tarcmd #{dest} #{src}")
+        expect(STDERR).to receive(:puts).once.ordered
+          .with("tar command stderr:\nsome stderr")
+        expect(File).to_not receive(:open)
+        expect { subject.make }.to raise_error(
+          RuntimeError, /ERROR: tarcmd exited 3/)
+      end
+    end
+    context 'when destination file does not exist' do
+      let(:subject) { Backupsss::Tar.new(src, dest) }
+      let(:dbl_file) { double(File) }
+      let(:dbl_status) { dbl_exitstatus(0) }
+      before(:each) do
+        allow(subject).to receive(:valid_dest?).and_return(true)
+        allow(subject).to receive(:valid_src?).and_return(true)
+        allow(subject).to receive(:tar_command).and_return('tarcmd')
+        allow(Open3).to receive(:capture3).and_return(['', '', dbl_status])
+        allow(STDERR).to receive(:puts)
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:size).and_return(999)
+        allow(File).to receive(:open).and_return(dbl_file)
+      end
+
+      it 'raises an error' do
+        expect(subject).to receive(:valid_dest?).once.ordered
+        expect(subject).to receive(:valid_src?).once.ordered
+        expect(Open3).to receive(:capture3).once.ordered
+          .with("tarcmd #{dest} #{src}")
+        expect(STDERR).to_not receive(:puts)
+        expect(File).to receive(:exist?).once.with(dest)
+        expect(File).to_not receive(:open)
+        expect { subject.make }.to raise_error(
+          RuntimeError, /ERROR: Tar destination file does not exist/)
+      end
+    end
+    context 'when destination file is 0 bytes' do
+      let(:subject) { Backupsss::Tar.new(src, dest) }
+      let(:dbl_file) { double(File) }
+      let(:dbl_status) { dbl_exitstatus(0) }
+      before(:each) do
+        allow(subject).to receive(:valid_dest?).and_return(true)
+        allow(subject).to receive(:valid_src?).and_return(true)
+        allow(subject).to receive(:tar_command).and_return('tarcmd')
+        allow(Open3).to receive(:capture3).and_return(['', '', dbl_status])
+        allow(STDERR).to receive(:puts)
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:size).and_return(0)
+        allow(File).to receive(:open).and_return(dbl_file)
+      end
+
+      it 'raises an error' do
+        expect(subject).to receive(:valid_dest?).once.ordered
+        expect(subject).to receive(:valid_src?).once.ordered
+        expect(Open3).to receive(:capture3).once.ordered
+          .with("tarcmd #{dest} #{src}")
+        expect(STDERR).to_not receive(:puts)
+        expect(File).to receive(:exist?).once.ordered.with(dest)
+        expect(File).to receive(:size).once.ordered.with(dest)
+        expect(File).to_not receive(:open)
+        expect { subject.make }.to raise_error(
+          RuntimeError, /ERROR: Tar destionation file is 0 bytes\./)
       end
     end
   end

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -164,8 +164,8 @@ describe Backupsss::Tar do
         expect(STDERR).to receive(:puts).once.ordered
           .with("tar command stderr:\nsome stderr")
         expect(File).to_not receive(:open)
-        expect { subject.make }.to raise_error(
-          RuntimeError, /ERROR: tarcmd exited 3/)
+        expect { subject.make }
+          .to raise_error(RuntimeError, /ERROR: tarcmd exited 3/)
       end
     end
     context 'when destination file does not exist' do
@@ -192,7 +192,8 @@ describe Backupsss::Tar do
         expect(File).to receive(:exist?).once.with(dest)
         expect(File).to_not receive(:open)
         expect { subject.make }.to raise_error(
-          RuntimeError, /ERROR: Tar destination file does not exist/)
+          RuntimeError, /ERROR: Tar destination file does not exist/
+        )
       end
     end
     context 'when destination file is 0 bytes' do
@@ -220,7 +221,8 @@ describe Backupsss::Tar do
         expect(File).to receive(:size).once.ordered.with(dest)
         expect(File).to_not receive(:open)
         expect { subject.make }.to raise_error(
-          RuntimeError, /ERROR: Tar destionation file is 0 bytes\./)
+          RuntimeError, /ERROR: Tar destionation file is 0 bytes\./
+        )
       end
     end
   end

--- a/spec/backupsss_spec.rb
+++ b/spec/backupsss_spec.rb
@@ -1,7 +1,41 @@
 require 'spec_helper'
+require 'rufus-scheduler'
+require 'backupsss'
 
 describe Backupsss do
   it 'has a version number' do
     expect(Backupsss::VERSION).not_to be nil
+  end
+
+  describe '#run' do
+    let(:scheduler) { double(Rufus::Scheduler) }
+    let(:config_hash) do
+      {
+        s3_bucket_prefix: 'some_prefix',
+        s3_bucket: 's3://some_bucket',
+        filename: filename,
+        backup_freq: '0 * * * *'
+      }
+    end
+    let(:subject) do
+      b = Backupsss
+      dbl_conf = double
+      allow(dbl_conf).to receive(:backup_freq).and_return('0 * * * *')
+      b.instance_variable_set(:@config, dbl_conf)
+      b
+    end
+    it 'sets the cron target to #call and calls #join' do
+      allow(Rufus::Scheduler).to receive(:new).and_return(scheduler)
+      allow(scheduler).to receive(:cron) { |&block| block.call }
+      allow(scheduler).to receive(:join)
+      allow(subject).to receive(:call)
+
+      expect(Rufus::Scheduler).to receive(:new).once.ordered
+      expect(scheduler).to receive(:cron).once.ordered
+        .with('0 * * * *', blocking: true)
+      expect(subject).to receive(:call).once.ordered
+      expect(scheduler).to receive(:join).once.ordered
+      subject.run
+    end
   end
 end

--- a/spec/backupsss_spec.rb
+++ b/spec/backupsss_spec.rb
@@ -43,7 +43,7 @@ describe Backupsss do
       allow(Rufus::Scheduler).to receive(:new).and_return(scheduler)
       allow(scheduler).to receive(:cron) { |&block| block.call }
       allow(scheduler).to receive(:join)
-      allow(subject).to receive(:call).and_raise(RuntimeError, "myerror")
+      allow(subject).to receive(:call).and_raise(RuntimeError, 'myerror')
       allow(STDERR).to receive(:puts)
 
       expect(Rufus::Scheduler).to receive(:new).once.ordered

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,10 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::Console]
 )
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/vendor/'
+  add_filter '/spec/'
+end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 


### PR DESCRIPTION
This adds a number of fixes:

* replace the actual filesystem IO in the Tar unit tests with doubles, so unit tests don't actually do filesystem IO.
* make rubocop a little less picky about metrics
* bump the circleci RVM version to 2.2.5, since ruby_dep requires that
* in Backupsss.run, rescue exceptions and log them with a traceback and a predictable error, instead of just dying
* in Backupsss::Tar.make, raise an exception if:
  * tar exits non-zero
  * the destination file doesn't exist
  * the destination file is 0 bytes in size
* added test coverage for all this
* fixed rubocop errors