### PR TITLE
Add support for multipart uploads...

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
 AllCops:
+  Exclude:
+    - '*.gemspec'
   TargetRubyVersion: 2.1

--- a/backupsss.gemspec
+++ b/backupsss.gemspec
@@ -41,5 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
 
   spec.add_runtime_dependency 'aws-sdk'
+  spec.add_runtime_dependency 'parallel'
   spec.add_runtime_dependency 'rufus-scheduler'
 end

--- a/backupsss.gemspec
+++ b/backupsss.gemspec
@@ -35,12 +35,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rspec', '~> 4.6.4'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
   spec.add_development_dependency 'guard-bundler', '~> 2.1'
-  spec.add_development_dependency 'rubocop', '~> 0.37'
+  spec.add_development_dependency 'rubocop', '0.46'
   spec.add_development_dependency 'simplecov', '~> 0.11.2'
   spec.add_development_dependency 'simplecov-console', '~> 0.3.0'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
 
-  spec.add_runtime_dependency 'aws-sdk'
-  spec.add_runtime_dependency 'parallel'
-  spec.add_runtime_dependency 'rufus-scheduler'
+  spec.add_runtime_dependency 'aws-sdk', '~> 2.7.0'
+  spec.add_runtime_dependency 'parallel', '~> 1.10.0'
+  spec.add_runtime_dependency 'rufus-scheduler', '~> 3.3.2'
 end

--- a/lib/backupsss/backup.rb
+++ b/lib/backupsss/backup.rb
@@ -1,19 +1,62 @@
 module Backupsss
   # A class for delivering a tar to S3
   class Backup
+    MAX_FILE_SIZE = 1024 * 1024 * 100 # 100MB
+
     attr_reader :config, :client, :filename
 
     def initialize(config, client)
-      @config       = config
-      @client       = client
+      @config   = config
+      @client   = client
       @filename = config[:filename]
     end
 
     def put_file(file)
-      client.put_object(bucket_opts.merge(body: file))
+      large_file(file) ? multi_upload(file) : single_upload(file)
     end
 
     private
+
+    def large_file(file)
+      file.size > MAX_FILE_SIZE
+    end
+
+    def multi_upload(file)
+      multipart_resp = client.create_multipart_upload(bucket_opts)
+      upload_parts(file, multipart_resp.upload_id)
+
+      client.complete_multipart_upload(
+        bucket_opts.merge(
+          upload_id: multipart_resp.upload_id
+        )
+      )
+    end
+
+    def upload_parts(file, upload_id)
+      (1..part_count(file)).inject([]) do |responses, part|
+        r = client.upload_part(
+          upload_part_params(file, part, upload_id)
+        )
+        r.on_success { $stdout.puts "Successfully uploaded part #{part}" }
+        responses << r
+      end
+    end
+
+    def upload_part_params(file, part, upload_id)
+      bucket_opts.merge(
+        part_number: part,
+        body: file.read(MAX_FILE_SIZE),
+        upload_id: upload_id
+      )
+    end
+
+    def part_count(file)
+      (file.size.to_f / MAX_FILE_SIZE.to_f).ceil
+    end
+
+    def single_upload(file)
+      client.put_object(bucket_opts.merge(body: file.read))
+    end
 
     def bucket_opts
       {

--- a/lib/backupsss/backup.rb
+++ b/lib/backupsss/backup.rb
@@ -17,13 +17,25 @@ module Backupsss
 
     private
 
+    def create_multipart_upload
+      $stdout.puts 'Creating a multipart upload'
+
+      client.create_multipart_upload(bucket_opts)
+    end
+
     def large_file(file)
       file.size > MAX_FILE_SIZE
     end
 
+    def complete_multipart_upload_request(upload_id, parts)
+      bucket_opts.merge(
+        upload_id: upload_id,
+        multipart_upload: { parts: parts }
+      )
+    end
+
     def multi_upload(file)
-      multipart_resp = client.create_multipart_upload(bucket_opts)
-      upload_parts(file, multipart_resp.upload_id)
+      upload_id = create_multipart_upload.upload_id
 
       client.complete_multipart_upload(
         bucket_opts.merge(
@@ -51,7 +63,10 @@ module Backupsss
     end
 
     def part_count(file)
-      (file.size.to_f / MAX_FILE_SIZE.to_f).ceil
+      c = (file.size.to_f / MAX_FILE_SIZE.to_f).ceil
+      $stdout.puts "Uploading backup as #{c} parts"
+
+      c
     end
 
     def single_upload(file)

--- a/lib/backupsss/backup.rb
+++ b/lib/backupsss/backup.rb
@@ -36,8 +36,7 @@ module Backupsss
 
     def complete_multipart_upload_request(upload_id, parts)
       bucket_opts.merge(
-        upload_id: upload_id,
-        multipart_upload: { parts: parts }
+        upload_id: upload_id, multipart_upload: { parts: parts }
       )
     end
 
@@ -106,11 +105,9 @@ module Backupsss
 
     def upload_part_params(file, part, upload_id)
       start = (part - 1) * MAX_FILE_SIZE
-      bucket_opts.merge(
-        part_number: part,
-        body: IO.read(file.path, MAX_FILE_SIZE, start),
-        upload_id: upload_id
-      )
+      body  = IO.read(file.path, MAX_FILE_SIZE, start)
+
+      bucket_opts.merge(part_number: part, body: body, upload_id: upload_id)
     end
 
     def part_count(file)

--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -37,8 +37,8 @@ module Backupsss
 
     def messages
       {
-        :no_file   => 'ERROR: Tar destination file does not exist',
-        :zero_byte => 'ERROR: Tar destination file is 0 bytes.'
+        no_file:   'ERROR: Tar destination file does not exist.',
+        zero_byte: 'ERROR: Tar destination file is 0 bytes.'
       }
     end
 

--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -30,12 +30,16 @@ module Backupsss
     end
 
     def valid_file?
-      missing_msg   = 'ERROR: Tar destination file does not exist'
-      zero_byte_msg = 'ERROR: Tar destination file is 0 bytes.'
-
-      raise missing_msg unless File.exist?(dest)
-      raise zero_byte_msg if File.size(dest).zero?
+      raise messages[:no_file] unless File.exist?(dest)
+      raise messages[:zero_byte] if File.size(dest).zero?
       true
+    end
+
+    def messages
+      {
+        :no_file   => 'ERROR: Tar destination file does not exist',
+        :zero_byte => 'ERROR: Tar destination file is 0 bytes.'
+      }
     end
 
     def valid_dest?

--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -14,19 +14,19 @@ module Backupsss
     def make
       return unless valid_dest? && valid_src?
       _, err, status = Open3.capture3("#{tar_command} #{dest} #{src}")
-      File.open(dest) if valid_exit?(status.exitstatus, err) && valid_file?
+      File.open(dest) if valid_exit?(status, err) && valid_file?
     end
 
-    def valid_exit?(exitstatus, err)
-      $stderr.puts "tar command stderr:\n#{err}" unless err.empty?
+    def valid_exit?(status, err)
+      output = []
+      output << "command.......#{tar_command}"
+      output << "stderr........#{err}" unless err.empty?
+      output << "status........#{status}"
+      output << "exit code.....#{status.to_i}"
+      $stdout.puts output.join("\n")
 
-      if exitstatus.zero?
-        true
-      elsif exitstatus == 1 && err.match(/file changed as we read it/)
-        true
-      else
-        raise "ERROR: #{tar_command} exited #{exitstatus}"
-      end
+      return true if success_cases(status.to_i, err)
+      raise "ERROR: #{tar_command} exited #{status.to_i}"
     end
 
     def valid_file?
@@ -56,6 +56,10 @@ module Backupsss
 
     private
 
+    def clean_exit(status)
+      status.zero?
+    end
+
     def dest_dir
       File.dirname(dest)
     end
@@ -68,8 +72,16 @@ module Backupsss
       File.exist?(File.open(dir)) || raise_sys_err(dir, Errno::ENOENT::Errno)
     end
 
+    def file_changed?(signal_int, err)
+      signal_int == 1 && err.match(/file changed as we read it/)
+    end
+
     def src_readable?
       File.readable?(src) || raise_sys_err(src, Errno::EPERM::Errno)
+    end
+
+    def success_cases(signal_int, err)
+      clean_exit(signal_int) || file_changed?(signal_int, err)
     end
 
     def raise_sys_err(dir, err)

--- a/spec/backupsss/backup_spec.rb
+++ b/spec/backupsss/backup_spec.rb
@@ -1,29 +1,98 @@
 require 'spec_helper'
 require 'backupsss/backup'
+require 'aws-sdk'
 
-describe Backupsss::Backup do
-  let(:filename) { 'somekey.tar' }
-  let(:key)      { "some_prefix/#{filename}" }
+describe Backupsss::Backup, :ignore_stdout do
+  let(:filename)    { 'somekey.tar' }
+  let(:key)         { "some_prefix/#{filename}" }
+  let(:client)      { Aws::S3::Client.new(stub_responses: true) }
+  let(:backup)      { Backupsss::Backup.new(config_hash, client) }
+  let(:filesize)    { 0 }
+  let(:bucket_opts) { { bucket: 'some_bucket', key: key } }
+  let(:sm)          { 1024 * 1024 * 100 }
+  let(:lg)          { 1024 * 1024 * 150 }
+  let(:max_size)    { 104_857_600 }
   let(:config_hash) do
     {
       s3_bucket_prefix: 'some_prefix',
-      s3_bucket: 's3://some_bucket',
+      s3_bucket: 'some_bucket',
       filename: filename
     }
   end
-  let(:backup) { Backupsss::Backup.new(config_hash, client) }
-  let(:file)   { instance_double('File') }
-  let(:client) { double }
+
+  let(:file) { instance_double('File', read: 'foo', size: filesize) }
 
   describe '#put_file' do
-    it 'uploads the file to the s3 location defined by the config' do
-      allow(client).to receive(:put_object)
-        .with(bucket: 's3://some_bucket', key: key, body: file)
+    context 'with a file smaller than 100 MB' do
+      before         { client.stub_responses(:put_object) }
+      let(:filesize) { sm }
 
-      backup.put_file(file)
+      subject { backup.put_file(file) }
+      it      { is_expected.to be_a(Seahorse::Client::Response) }
 
-      expect(client).to have_received(:put_object)
-        .with(bucket: 's3://some_bucket', key: key, body: file)
+      context 'on successful upload' do
+        subject { backup.put_file(file).successful? }
+        it      { is_expected.to be_truthy }
+      end
+
+      context 'on failed upload' do
+        before  { client.stub_responses(:put_object, Timeout::Error) }
+        subject { -> { backup.put_file(file) } }
+        it      { is_expected.to raise_error(Timeout::Error) }
+      end
+    end
+
+    context 'with a file bigger than 100 MB' do
+      let(:filesize) { lg }
+
+      subject        { backup.put_file(file) }
+      it             { is_expected.to be_a(Seahorse::Client::Response) }
+
+      context 'on successful upload' do
+        let(:upload_part_responses) do
+          [
+            { etag: rand(100_000).to_s },
+            { etag: rand(100_000).to_s }
+          ]
+        end
+
+        let(:create_upload_response) do
+          { upload_id: rand(100_000).to_s }
+        end
+
+        let(:complete_multipart_upload_response) do
+          {
+            bucket: bucket_opts[:bucket],
+            key:    bucket_opts[:key]
+          }
+        end
+
+        before do
+          client.stub_responses(:upload_part, upload_part_responses)
+          client.stub_responses(
+            :create_multipart_upload,
+            create_upload_response
+          )
+          client.stub_responses(
+            :complete_multipart_upload, complete_multipart_upload_response
+          )
+        end
+
+        subject { backup.put_file(file).successful? }
+        it      { is_expected.to be_truthy }
+
+        it 'returns a completed multipart upload' do
+          expect(backup.put_file(file).bucket).to eq(bucket_opts[:bucket])
+        end
+
+        context 'stdout' do
+          subject { -> { backup.put_file(file) } }
+          let(:msg) do
+            "Successfully uploaded part 1\nSuccessfully uploaded part 2\n"
+          end
+          it { is_expected.to output(msg).to_stdout }
+        end
+      end
     end
   end
 end

--- a/spec/backupsss/backup_spec.rb
+++ b/spec/backupsss/backup_spec.rb
@@ -5,13 +5,14 @@ require 'aws-sdk'
 describe Backupsss::Backup, :ignore_stdout do
   let(:filename)    { 'somekey.tar' }
   let(:key)         { "some_prefix/#{filename}" }
-  let(:client)      { Aws::S3::Client.new(stub_responses: true) }
   let(:backup)      { Backupsss::Backup.new(config_hash, client) }
   let(:filesize)    { 0 }
   let(:bucket_opts) { { bucket: 'some_bucket', key: key } }
   let(:sm)          { 1024 * 1024 * 100 }
   let(:lg)          { 1024 * 1024 * 150 }
-  let(:max_size)    { 104_857_600 }
+  let(:max_size)    { sm }
+  let(:upload_id)   { rand(100_000).to_s }
+  let(:aws_stubs)   { {} }
   let(:config_hash) do
     {
       s3_bucket_prefix: 'some_prefix',
@@ -20,77 +21,203 @@ describe Backupsss::Backup, :ignore_stdout do
     }
   end
 
-  let(:file) { instance_double('File', read: 'foo', size: filesize) }
+  let(:file) do
+    instance_double('File', read: 'foo', path: filename, size: filesize)
+  end
+
+  let(:client) do
+    c = Aws::S3::Client.new(stub_responses: true)
+    aws_stubs.each do |msg, resp|
+      c.stub_responses(msg.to_sym, resp)
+    end
+
+    c
+  end
+
+  before do
+    allow(IO).to receive(:read).and_return('foo')
+  end
 
   describe '#put_file' do
-    context 'with a file smaller than 100 MB' do
-      before         { client.stub_responses(:put_object) }
-      let(:filesize) { sm }
+    context 'while checking filesize' do
+      it 'informs of activity' do
+        info = 'Checking backup size ...'
 
-      subject { backup.put_file(file) }
-      it      { is_expected.to be_a(Seahorse::Client::Response) }
-
-      context 'on successful upload' do
-        subject { backup.put_file(file).successful? }
-        it      { is_expected.to be_truthy }
-      end
-
-      context 'on failed upload' do
-        before  { client.stub_responses(:put_object, Timeout::Error) }
-        subject { -> { backup.put_file(file) } }
-        it      { is_expected.to raise_error(Timeout::Error) }
+        expect { backup.put_file(file) }
+          .to output(/#{info}/).to_stdout
       end
     end
 
-    context 'with a file bigger than 100 MB' do
+    context 'with a file < 100 MB' do
+      let(:filesize)  { sm }
+      let(:aws_stubs) { { put_object: nil } }
+
+      it 'informs about a small file' do
+        info = 'Size of backup is less than 100MB'
+
+        expect { backup.put_file(file) }
+          .to output(/#{info}/).to_stdout
+      end
+
+      it 'sends put_object to the client once' do
+        expect(client).to receive(:put_object).once
+
+        backup.put_file(file)
+      end
+    end
+
+    context 'with a file > 100 MB' do
       let(:filesize) { lg }
-
-      subject        { backup.put_file(file) }
-      it             { is_expected.to be_a(Seahorse::Client::Response) }
-
-      context 'on successful upload' do
-        let(:upload_part_responses) do
-          [
-            { etag: rand(100_000).to_s },
-            { etag: rand(100_000).to_s }
-          ]
-        end
-
-        let(:create_upload_response) do
-          { upload_id: rand(100_000).to_s }
-        end
-
-        let(:complete_multipart_upload_response) do
-          {
+      let(:aws_stubs) do
+        {
+          upload_part: (1..2).map { { etag: 'ETag' } },
+          create_multipart_upload: {
+            upload_id: upload_id
+          },
+          complete_multipart_upload: {
             bucket: bucket_opts[:bucket],
             key:    bucket_opts[:key]
           }
+        }
+      end
+
+      it 'informs about a large file' do
+        info = 'Size of backup is greater than 100MB'
+
+        expect { backup.put_file(file) }
+          .to output(/#{info}/).to_stdout
+      end
+
+      it 'informs about part count' do
+        info = 'Uploading backup as 2 parts'
+
+        expect { backup.put_file(file) }
+          .to output(/#{info}/).to_stdout
+      end
+
+      context 'while creating multi part upload' do
+        it 'informs about activity' do
+          info = 'Creating a multipart upload'
+
+          expect { backup.put_file(file) }
+            .to output(/#{info}/).to_stdout
         end
+      end
 
-        before do
-          client.stub_responses(:upload_part, upload_part_responses)
-          client.stub_responses(
-            :create_multipart_upload,
-            create_upload_response
-          )
-          client.stub_responses(
-            :complete_multipart_upload, complete_multipart_upload_response
-          )
-        end
-
-        subject { backup.put_file(file).successful? }
-        it      { is_expected.to be_truthy }
-
-        it 'returns a completed multipart upload' do
-          expect(backup.put_file(file).bucket).to eq(bucket_opts[:bucket])
-        end
-
-        context 'stdout' do
-          subject { -> { backup.put_file(file) } }
-          let(:msg) do
-            "Successfully uploaded part 1\nSuccessfully uploaded part 2\n"
+      context 'while uploading parts' do
+        it 'informs about activity' do
+          infos = (1..2).map do |i|
+            "#{upload_id}: Uploading part number #{i}"
           end
-          it { is_expected.to output(msg).to_stdout }
+
+          expect { backup.put_file(file) }
+            .to output(/#{infos[0]}.*#{infos[1]}/m).to_stdout
+        end
+
+        it 'sends upload_part to the client for each part' do
+          (1..2).each do |i|
+            expect(client).to receive(:upload_part)
+              .with(hash_including(upload_id: upload_id, part_number: i))
+              .and_call_original
+          end
+
+          backup.put_file(file)
+        end
+
+        context 'and all parts succeed' do
+          it 'informs about successes' do
+            expect { backup.put_file(file) }
+              .to output(/Completed uploading part number [12]/m).to_stdout
+          end
+
+          it 'sends complete_multipart_upload to the client once' do
+            params = {
+              upload_id: upload_id,
+              multipart_upload: {
+                parts: (1..2).map { |i| { etag: 'ETag', part_number: i } }
+              }
+            }
+
+            expect(client).to receive(:complete_multipart_upload)
+              .with(hash_including(params)).once
+
+            backup.put_file(file)
+          end
+        end
+
+        context 'and some parts failed' do
+          let(:error) { Timeout::Error.new('Took too long foo!') }
+          let(:aws_stubs) do
+            {
+              upload_part: [
+                error,
+                { etag: 'ETag' }
+              ],
+              create_multipart_upload: {
+                upload_id: upload_id
+              },
+              complete_multipart_upload: {
+                bucket: bucket_opts[:bucket],
+                key:    bucket_opts[:key]
+              }
+            }
+          end
+
+          context 'handles and informs about different Exceptions' do
+            context 'Timeout error' do
+              it 'informs about error with message' do
+                info = 'because of Took too long foo!'
+
+                expect { backup.put_file(file) }
+                  .to output(/#{info}/).to_stdout
+              end
+            end
+
+            context 'NotFound error' do
+              let(:error) { 'NotFound' }
+
+              it 'informs about error with message' do
+                info = 'because of stubbed-response-error-message'
+
+                expect { backup.put_file(file) }
+                  .to output(/#{info}/).to_stdout
+              end
+            end
+          end
+
+          it 'informs about failure with offending part number' do
+            info = "#{upload_id}: Failed to upload part number 1"
+
+            expect { backup.put_file(file) }
+              .to output(/#{info}/).to_stdout
+          end
+
+          it 'does not call upload part for part 2' do
+            expect(client).to receive(:upload_part).once.and_call_original
+
+            backup.put_file(file)
+          end
+
+          it 'informs about aborting remaining parts' do
+            infos = "#{upload_id}: Aborting remaining parts"
+
+            expect { backup.put_file(file) }
+              .to output(/#{infos}/).to_stdout
+          end
+
+          it 'calls abort_multipart_upload and notifies' do
+            params = {
+              bucket: bucket_opts[:bucket],
+              key:    bucket_opts[:key],
+              upload_id: upload_id
+            }
+
+            expect(client).to receive(:abort_multipart_upload)
+              .with(hash_including(params)).once
+
+            expect { backup.put_file(file) }
+              .to output(/#{upload_id}: Aborting multipart upload/).to_stdout
+          end
         end
       end
     end

--- a/spec/backupsss/backup_spec.rb
+++ b/spec/backupsss/backup_spec.rb
@@ -53,7 +53,7 @@ describe Backupsss::Backup, :ignore_stdout do
       let(:aws_stubs) { { put_object: nil } }
 
       it 'informs about a small file' do
-        info = 'Size of backup is less than 100MB'
+        info = 'Size of backup is less than or equal to 100MB'
 
         expect { backup.put_file(file) }
           .to output(/#{info}/).to_stdout

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -92,7 +92,7 @@ describe Backupsss::Tar, :ignore_stdout do
   end
 
   describe '#valid_file?' do
-    let(:missing_msg)   { 'ERROR: Tar destination file does not exist' }
+    let(:missing_msg)   { 'ERROR: Tar destination file does not exist.' }
     let(:zero_byte_msg) { 'ERROR: Tar destination file is 0 bytes.' }
     subject { -> { Backupsss::Tar.new(valid_src, dest).valid_file? } }
 

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'backupsss/tar'
 
-describe Backupsss::Tar do
+describe Backupsss::Tar, :ignore_stdout do
   let(:empty_src) { 'spec/fixtures/backup_src/empty' }
   let(:valid_src) { 'spec/fixtures/backup_src/with_data' }
   let(:src)       { 'spec/fixtures/backup_src' }
@@ -86,7 +86,7 @@ describe Backupsss::Tar do
       end
 
       it 'exits cleanly' do
-        expect { subject.make }.to_not output.to_stderr
+        expect { subject.make }.to_not raise_error
       end
     end
   end
@@ -124,28 +124,36 @@ describe Backupsss::Tar do
   end
 
   describe '#valid_exit?' do
+    Status = Struct.new(:to_i, :to_s)
     let(:err) { '' }
 
     context 'when status is zero' do
-      let(:status) { 0 }
+      let(:status) { Status.new(0, 'pid 18327 exit 0') }
       subject { Backupsss::Tar.new(valid_src, dest).valid_exit?(status, err) }
 
       it { is_expected.to eq(true) }
     end
 
     context 'when status is greater than 1' do
-      let(:status) { 2 }
+      let(:status) { Status.new(2, 'pid 21320 SIGINT (signal 2)') }
       subject do
         -> { Backupsss::Tar.new(valid_src, dest).valid_exit?(status, err) }
       end
 
-      it { is_expected.to raise_error(/ERROR: tar.* exited #{status}/) }
+      it { is_expected.to raise_error(/ERROR: tar.* exited #{status.to_i}/) }
     end
 
     context 'when status is 1 with valid warning' do
-      let(:status)          { 1 }
+      let(:status)          { Status.new(1, 'pid 16145 SIGHUP (signal 1)') }
       let(:err)             { 'file: file changed as we read it' }
-      let(:expected_output) { "tar command stderr:\n#{err}\n" }
+      let(:expected_output) do
+        [
+          "command.......tar -zcvf\n",
+          "stderr........#{err}\n",
+          "status........pid 16145 SIGHUP (signal 1)\n",
+          "exit code.....1\n"
+        ].join
+      end
 
       subject do
         Backupsss::Tar.new(valid_src, dest).valid_exit?(status, err)
@@ -159,7 +167,7 @@ describe Backupsss::Tar do
         end
 
         it { is_expected.to_not raise_error }
-        it { is_expected.to output(expected_output).to_stderr }
+        it { is_expected.to output(expected_output).to_stdout }
       end
     end
   end


### PR DESCRIPTION
when files are greater than 100MB backupsss will create a multipart upload, split the file into 100MB chunks, and upload each part utilizing 10 threads(current default, should be configurable in the future), and call the complete multipart upload api call with the responses for each part upload.

This PR also includes a fix for the tar class where exitstatus was being called on nil from time to time.