### PR TITLE
Oneshot

### DIFF
--- a/backupsss.gemspec
+++ b/backupsss.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'aws-sdk', '~> 2.7.0'
   spec.add_runtime_dependency 'parallel', '~> 1.10.0'
-  spec.add_runtime_dependency 'rufus-scheduler', '~> 3.3.2'
+  spec.add_runtime_dependency 'rufus-scheduler', '3.4.0'
 end

--- a/exe/backupsss
+++ b/exe/backupsss
@@ -3,4 +3,4 @@
 require 'backupsss'
 $stdout.sync = true
 $stderr.sync = true
-Backupsss.run
+Backupsss::Runner.new.run

--- a/lib/backupsss.rb
+++ b/lib/backupsss.rb
@@ -10,6 +10,7 @@ require 'backupsss/configuration'
 
 # A utility for backing things up to S3.
 module Backupsss
+  # A Class for running this backup utility
   class Runner
     attr_accessor :config
 
@@ -22,6 +23,7 @@ module Backupsss
     end
 
     private
+
     def call
       push_backup(*prep_for_backup)
       cleanup_local
@@ -70,28 +72,25 @@ module Backupsss
       remote_janitor.rm_garbage(remote_janitor.sift_trash)
     end
 
-
     def run_scheduled
       $stdout.puts "Schedule provided, running with #{config.backup_freq}"
 
       scheduler = Rufus::Scheduler.new
-      scheduler.cron(config.backup_freq, blocking: true){ make_call }
+      scheduler.cron(config.backup_freq, blocking: true) { make_call }
       scheduler.join
     end
 
     def run_oneshot
-      $stdout.puts "No Schedule provided, running one time task"
+      $stdout.puts 'No Schedule provided, running one time task'
 
       make_call
     end
 
     def make_call
-      begin
-        call
-      rescue => exc
-        $stderr.puts "ERROR - backup failed: #{exc.message}"
-        $stderr.puts exc.backtrace.join("\n\t")
-      end
+      call
+    rescue => exc
+      $stderr.puts "ERROR - backup failed: #{exc.message}"
+      $stderr.puts exc.backtrace.join("\n\t")
     end
   end
 end

--- a/lib/backupsss/configuration.rb
+++ b/lib/backupsss/configuration.rb
@@ -40,7 +40,7 @@ module Backupsss
     end
 
     def throwout_nils(attrs)
-      attrs.reject { |_, v| v.nil? }
+      attrs.reject { |k, v| v.nil? && k != :backup_freq  }
     end
 
     def attrs

--- a/lib/backupsss/configuration.rb
+++ b/lib/backupsss/configuration.rb
@@ -40,7 +40,7 @@ module Backupsss
     end
 
     def throwout_nils(attrs)
-      attrs.reject { |k, v| v.nil? && k != :backup_freq  }
+      attrs.reject { |k, v| v.nil? && k != :backup_freq }
     end
 
     def attrs

--- a/lib/backupsss/version.rb
+++ b/lib/backupsss/version.rb
@@ -1,3 +1,3 @@
 module Backupsss
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/backupsss/configuration_spec.rb
+++ b/spec/backupsss/configuration_spec.rb
@@ -3,10 +3,20 @@ require 'backupsss/configuration'
 
 describe Backupsss::Configuration do
   context '#initialize' do
-    describe 'missing attributes' do
+    describe 'attributes' do
       let(:invalid_args) do
         {
-          s3_bucket:        'a_bucket',
+          s3_bucket_prefix: 'mah_bucket_key',
+          backup_src_dir:   '/local/path',
+          backup_dest_dir:  '/backup',
+          backup_freq:      '0 * * * *',
+          aws_region:       'us-east-1'
+        }
+      end
+
+      let(:no_schedule_args) do
+        {
+          s3_bucket:        'mah_bucket',
           s3_bucket_prefix: 'mah_bucket_key',
           backup_src_dir:   '/local/path',
           backup_dest_dir:  '/backup',
@@ -14,7 +24,12 @@ describe Backupsss::Configuration do
         }
       end
 
-      let(:missing_arg) { 'backup_freq' }
+      let(:missing_arg) { 's3_bucket' }
+
+      it 'does not raise if backup_freq is not supplied' do
+        expect { Backupsss::Configuration.new(no_schedule_args) }
+          .to_not raise_error(ArgumentError)
+      end
 
       it 'raises ArgumentError when attributes are missing' do
         expect { Backupsss::Configuration.new(invalid_args) }

--- a/spec/backupsss_spec.rb
+++ b/spec/backupsss_spec.rb
@@ -48,13 +48,12 @@ describe Backupsss do
             'AWS_REGION'       => 'us-east-1',
             'REMOTE_RETENTION' => '2'
           )
-
         end
 
         it 'should notify running scheduled job' do
           msg = "Schedule provided, running with #{ENV['BACKUP_FREQ']}\n"
 
-          expect{subject.run}.to output(msg).to_stdout
+          expect { subject.run }.to output(msg).to_stdout
         end
 
         it "should call scheduler's cron and join methods" do
@@ -85,16 +84,15 @@ describe Backupsss do
         it 'should notify running one time job' do
           msg = "No Schedule provided, running one time task\n"
 
-          expect{subject.run}.to output(msg).to_stdout
+          expect { subject.run }.to output(msg).to_stdout
         end
 
         it 'rescues from exceptions and writes a message to STDERR' do
           err_msg = 'ERROR - backup failed: myerror'
           allow(subject).to receive(:call).and_raise(RuntimeError, 'myerror')
 
-          expect{subject.run}.to output(/#{err_msg}/).to_stderr
+          expect { subject.run }.to output(/#{err_msg}/).to_stderr
         end
-
       end
     end
   end


### PR DESCRIPTION
This PR allows backupsss to be ran as a one time task if a schedule isn't provided via the 'BACKUP_FREQ' environment variable.

It also updates rufus-scheduler due to a dependency change in older versions that can cause errors with timezones.