### PR TITLE
fix(tar): ignore signal_int when checking file_changed?

### DIFF
--- a/lib/backupsss/tar.rb
+++ b/lib/backupsss/tar.rb
@@ -76,8 +76,8 @@ module Backupsss
       File.exist?(File.open(dir)) || raise_sys_err(dir, Errno::ENOENT::Errno)
     end
 
-    def file_changed?(signal_int, err)
-      signal_int == 1 && err.match(/file changed as we read it/)
+    def file_changed?(err)
+      err.match(/file changed as we read it/)
     end
 
     def src_readable?
@@ -85,7 +85,7 @@ module Backupsss
     end
 
     def success_cases(signal_int, err)
-      clean_exit(signal_int) || file_changed?(signal_int, err)
+      clean_exit(signal_int) || file_changed?(err)
     end
 
     def raise_sys_err(dir, err)

--- a/lib/backupsss/version.rb
+++ b/lib/backupsss/version.rb
@@ -1,3 +1,3 @@
 module Backupsss
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/spec/backupsss/tar_spec.rb
+++ b/spec/backupsss/tar_spec.rb
@@ -143,15 +143,17 @@ describe Backupsss::Tar, :ignore_stdout do
       it { is_expected.to raise_error(/ERROR: tar.* exited #{status.to_i}/) }
     end
 
-    context 'when status is 1 with valid warning' do
-      let(:status)          { Status.new(1, 'pid 16145 SIGHUP (signal 1)') }
+    context 'when error is a valid warning' do
+      let(:exit_code)       { 1 }
+      let(:status_msg)      { 'pid 8 exit 1' }
+      let(:status)          { Status.new(exit_code, status_msg) }
       let(:err)             { 'file: file changed as we read it' }
       let(:expected_output) do
         [
           "command.......tar -zcvf\n",
           "stderr........#{err}\n",
-          "status........pid 16145 SIGHUP (signal 1)\n",
-          "exit code.....1\n"
+          "status........#{status_msg}\n",
+          "exit code.....#{exit_code}\n"
         ].join
       end
 


### PR DESCRIPTION
Fixes issue #14 . Since the `clean_exit(...)` call will make fail for exit statuses > 0, we just need to watch for an allow for those cases where the message is like "file changed as we read it".